### PR TITLE
fix: actions heading alignment

### DIFF
--- a/src/Components/Masterdetail.php
+++ b/src/Components/Masterdetail.php
@@ -7,12 +7,16 @@ namespace Rodrigofs\FilamentMasterdetail\Components;
 use Filament\Actions\Concerns\CanOpenModal;
 use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\Component;
+use Filament\Forms\Components\Concerns\{CanBeAutofocused,
+    CanGenerateUuids,
+    CanLimitItemsLength,
+    HasHeaderActions as InteractsHeaderActions};
 use Filament\Forms\Components\Contracts\HasHeaderActions;
 use Filament\Support\Concerns\{HasDescription, HasHeading, HasIcon, HasIconColor};
-use Filament\Forms\Components\Concerns\{CanBeAutofocused, CanGenerateUuids, CanLimitItemsLength, HasHeaderActions as InteractsHeaderActions};
-use Rodrigofs\FilamentMasterdetail\Concerns\{CanDeleteAction, HasFormModal, HasRelationship, HasTable};
 use Filament\Tables\Columns\Concerns\HasName;
-use Illuminate\Support\Str;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\{HtmlString, Str};
+use Rodrigofs\FilamentMasterdetail\Concerns\{CanDeleteAction, HasFormModal, HasRelationship, HasTable};
 
 final class Masterdetail extends Component implements HasHeaderActions
 {
@@ -93,5 +97,14 @@ final class Masterdetail extends Component implements HasHeaderActions
         $this->headerActions = [
             $this->getAddAction(),
         ];
+    }
+
+    public function getHeading(): string | Htmlable | null
+    {
+        if (is_null($this->heading)) {
+            $this->heading = new HtmlString('&nbsp;'); // workaround: force right alignment when title will be set to null
+        }
+
+        return $this->evaluate($this->heading);
     }
 }

--- a/tests/src/MasterDetailTest.php
+++ b/tests/src/MasterDetailTest.php
@@ -131,6 +131,11 @@ it('can set the modal heading', function () {
         ->getModalHeading()->toBe('Test Title Modal');
 });
 
+it('can not set the heading', function () {
+    expect(Masterdetail::make(''))
+        ->getHeading()->toEqual('&nbsp;');
+});
+
 it('can modal persistent', function () {
     expect(Masterdetail::make(''))
         ->modalPersistent()


### PR DESCRIPTION
Force actions alignment to the right even when no heading is provided

![capture_250418_173242](https://github.com/user-attachments/assets/be315d3c-5d93-4343-b151-36e60f7ea150)
